### PR TITLE
Fix fetching of greater than pagesize pubs

### DIFF
--- a/R/publications.r
+++ b/R/publications.r
@@ -95,10 +95,10 @@ get_publications <- function(id, cstart = 0, pagesize=20) {
     ##    data <- as.data.frame(lapply(data,function(x) if(is.character(x)|is.factor(x)) gsub(" ","-",x) else x))
     ##    data <- as.data.frame(lapply(data,function(x) if(is.character(x)|is.factor(x)) gsub("\u0096","-",x) else x))
 
-    ## Check if we've reached a multiple of 100 articles. Might need
+    ## Check if we've reached pagesize articles. Might need
     ## to search the next page
-    if (nrow(data) > 0 && nrow(data)%%100 == 0) {
-      data <- rbind(data, get_publications(id, nrow(data)))
+    if (nrow(data) > 0 && nrow(data)==pagesize) {
+      data <- rbind(data, get_publications(id, cstart=cstart+pagesize, pagesize=pagesize))
     }
     
     ## Save it after everything has been retrieved.

--- a/R/publications.r
+++ b/R/publications.r
@@ -22,7 +22,7 @@
 ##' cites, year, and two id codes (see details).
 ##' @import stringr plyr R.cache XML
 ##' @export
-get_publications <- function(id, cstart = 0, pagesize=20) {
+get_publications <- function(id, cstart = 0, pagesize=100) {
 
   ## Ensure we're only getting one scholar's publications
   id <- tidy_id(id)

--- a/man/get_publications.Rd
+++ b/man/get_publications.Rd
@@ -3,7 +3,7 @@
 \alias{get_publications}
 \title{Gets the publications for a scholar}
 \usage{
-get_publications(id, cstart = 0, pagesize = 20)
+get_publications(id, cstart = 0, pagesize = 100)
 }
 \arguments{
 \item{id}{a character string specifying the Google Scholar ID.  If

--- a/man/get_publications.Rd
+++ b/man/get_publications.Rd
@@ -3,7 +3,7 @@
 \alias{get_publications}
 \title{Gets the publications for a scholar}
 \usage{
-get_publications(id, cstart = 0)
+get_publications(id, cstart = 0, pagesize = 20)
 }
 \arguments{
 \item{id}{a character string specifying the Google Scholar ID.  If
@@ -13,6 +13,9 @@ scholar will be retrieved.}
 \item{cstart}{an integer specifying the first article to start
 counting.  To get all publications for an author, omit this
 parameter.}
+
+\item{pagesize}{an integer specifying the number of articles to
+fetch}
 }
 \value{
 a data frame listing the publications and their details.


### PR DESCRIPTION
Hi @jkeirstead,

Thanks for the nice package. I've noticed that fetching of >pagesize publications by `get_publications` seems to be broken (on develop and on master). For example for myself:

```r
nrow(get_publications("cuXoCA8AAAAJ"))
nrow(get_publications('cuXoCA8AAAAJ', pagesize = 50))
```
both give 20 pubs. Proposed fix in attached.

I also suggest increasing `pagesize` since this has no substantial penalty for short publication lists but has a significant penalty for long lists. For example:

```r
# a colleague with 187 pubs
system.time(get_publications('G6ufCyYAAAAJ', pagesize = 100))
## restart R session or otherwise clear cache
system.time(get_publications('G6ufCyYAAAAJ', pagesize = 20))

## -> 1.06 vs 3.74 seconds for me
```