### PR TITLE
Use .onLoad to set scholar_call_home option

### DIFF
--- a/R/zzz.r
+++ b/R/zzz.r
@@ -1,3 +1,3 @@
-.onAttach <- function(libname, pkgname) {
-    options("scholar_call_home"=TRUE)
+.onLoad <- function(libname, pkgname) {
+  options("scholar_call_home"=TRUE)
 }


### PR DESCRIPTION
* otherwise the option will not be set when scholar is imported by another package
* this results in an error in tidy_id
* fixes https://github.com/jkeirstead/scholar/issues/25