### PR TITLE
Fixed issue in get_publications

### DIFF
--- a/R/publications.r
+++ b/R/publications.r
@@ -36,7 +36,10 @@ utils::globalVariables(c("."))
 get_publications <- function(id, cstart = 0, pagesize=100, flush=FALSE) {
 
     ## Make sure pagesize is not greater than max allowed by Google Scholar
-    if (pagesize > 100) pagesize <- 100
+    if (pagesize > 100) {
+        warning("pagesize: ", pagesize, " exceeds Google Scholar maximum. Setting to 100.")
+        pagesize <- 100
+    }
 
     ## Ensure we're only getting one scholar's publications
     id <- tidy_id(id)

--- a/R/publications.r
+++ b/R/publications.r
@@ -35,6 +35,9 @@ utils::globalVariables(c("."))
 ##' @export
 get_publications <- function(id, cstart = 0, pagesize=100, flush=FALSE) {
 
+    ## Make sure pagesize is not greater than max allowed by Google Scholar
+    if (pagesize > 100) pagesize <- 100
+
     ## Ensure we're only getting one scholar's publications
     id <- tidy_id(id)
 


### PR DESCRIPTION
`pagesize` > 100 would only return first page of author publications (first 100); this is because in the loop used in `get_publications`, the condition `nrow(data)==pagesize` is used (doesn't come true if pagesize > 100). Alternatively, the aforementioned condition could be altered, but this seemed a more robust change.