### PR TITLE
Allow users to get info on latest papers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,4 +33,4 @@ Suggests:
     prettydoc,
     roxygen2
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0

--- a/man/get_publications.Rd
+++ b/man/get_publications.Rd
@@ -4,7 +4,8 @@
 \alias{get_publications}
 \title{Gets the publications for a scholar}
 \usage{
-get_publications(id, cstart = 0, pagesize = 100, flush = FALSE)
+get_publications(id, cstart = 0, cstop = Inf, pagesize = 100,
+  flush = FALSE, sortby = "citation")
 }
 \arguments{
 \item{id}{a character string specifying the Google Scholar ID.  If
@@ -15,6 +16,9 @@ scholar will be retrieved.}
 counting.  To get all publications for an author, omit this
 parameter.}
 
+\item{cstop}{an integer specifying the last article to
+process.}
+
 \item{pagesize}{an integer specifying the number of articles to
 fetch}
 
@@ -22,6 +26,9 @@ fetch}
 cached by default to speed up repeated queries.  If this argument
 is TRUE, the cache will be cleared and the data reloaded from
 Google.}
+
+\item{sortby}{a character with value \code{"citation"} or
+value \code{"year"} specifying how results are sorted.}
 }
 \value{
 a data frame listing the publications and their details.


### PR DESCRIPTION
I understand if these changes need more testing before they can be incorporated. Great package! :+1: Cheers

commit message: get_publications function: Added cstop and sortby arguments to allow users to get info on latest papers. To get info on latest paper set cstat = 0, cstop = 0 and sortby = "year".