### PR TITLE
restore pubid

### DIFF
--- a/R/getCompleteAuthors.R
+++ b/R/getCompleteAuthors.R
@@ -21,8 +21,8 @@ get_complete_authors = function(id, pubid, delay = .4, initials = TRUE)
       url = sprintf(url_template, id, pubid)
       
       url1 <- get_scholar_resp(url[1]) %>%
-          read_html
-      auths = as.character(rvest::html_node(url1, ".gsc_vcd_value") %>% rvest::html_text())
+          read_html()
+      auths = as.character(rvest::html_node(url1, ".gsc_oci_value") %>% rvest::html_text())
       return(auths)
   }
 

--- a/R/publications.r
+++ b/R/publications.r
@@ -166,14 +166,13 @@ get_article_cite_history <- function (id, article) {
 
     ## Inspect the bar chart to retrieve the citation values and years
     years <- doc %>%
-        html_nodes(xpath="//*/div[@id='gsc_vcd_graph_bars']/a") %>%
-            html_attr("href") %>%
-                str_replace(".*as_yhi=(.*)$", "\\1") %>%
-                    as.numeric()
+        html_nodes(".gsc_oci_g_t") %>% 
+        html_text() %>% 
+        as.numeric()
     vals <- doc %>%
-        html_nodes(xpath="//*/span[@class='gsc_vcd_g_al']") %>%
-            html_text() %>%
-                as.numeric()
+        html_nodes(".gsc_oci_g_al") %>% 
+        html_text() %>% 
+        as.numeric()
 
     df <- data.frame(year = years, cites = vals)
     if(nrow(df)>0) {

--- a/R/publications.r
+++ b/R/publications.r
@@ -83,7 +83,7 @@ get_publications <- function(id, cstart = 0, cstop = Inf, pagesize=100, flush=FA
 
         title <- cites %>% html_nodes(".gsc_a_at") %>% html_text()
         pubid <- cites %>% html_nodes(".gsc_a_at") %>%
-            html_attr("data-href") %>% str_extract(":.*$") %>% str_sub(start=2)
+            html_attr("href") %>% str_extract(":.*$") %>% str_sub(start=2)
         doc_id <- cites %>% html_nodes(".gsc_a_ac") %>% html_attr("href") %>%
             str_extract("cites=.*$") %>% str_sub(start=7)
         cited_by <- suppressWarnings(cites %>% html_nodes(".gsc_a_ac") %>%

--- a/tests/testthat/test-scholar.R
+++ b/tests/testthat/test-scholar.R
@@ -32,6 +32,14 @@ test_that("get_citation_history works", {
     expect_equal(names(h), c("year", "cites"))
 })
 
+test_that("get_article_cite_history works", {
+  skip_on_cran()
+  skip_if_offline()
+  expect_is(ach <- get_article_cite_history("B7vSqZsAAAAJ", "hMod-77fHWUC"), 
+            'data.frame')
+  expect_equal(names(ach), c("year", "cites", "pubid"))
+})
+
 test_that("get_profile works", {
     skip_on_cran()
     skip_if_offline()


### PR DESCRIPTION
As mentioned in issue #96, get_publications() is currently returning all pubids as NA.

I suspect google has modified the page layout. The following commit restores pubid.